### PR TITLE
livedump: Update include for task-stack api's

### DIFF
--- a/Documentation/livedump.txt
+++ b/Documentation/livedump.txt
@@ -1,0 +1,50 @@
+==========================
+Live Application Core Dump
+==========================
+
+Live application core dump, or livedump, provides the ability to take a
+coredump of an application that is still running without killing the
+application, or stopping it for very long.
+
+Livedump works by performing a special fork of an application that
+copies all the threads, without allowing any of the threads to run.
+It does this in a PID namespace it creates so it can keep the
+process/thread ids the same.  Once the fork is done, the original
+application is free to run and the core dump is taken in the forked
+application.
+
+To enable this, enable CONFIG_LIVEDUMP in the kernel config.  If that
+is enabled, every process will have a file named "livedump" in
+/proc/<pid>.
+
+To take a livedump, echo an empty string to /proc/<pid>/livedump, like
+
+   echo "" >/proc/1234/livedump
+
+That process will take a core dump using the standard way the
+application would core dump.  Since the core limit (ulimit -c) is
+usually zero, that means that this won't do anything normally unless
+the core limit of the application is set.
+
+But all is not lost!  Livedump will let you override a number of
+things, including the core limit, in the forked application.  You can
+do this by putting it in the string sent to the livedump file, as:
+
+  echo "core_limit=unlimited" >/proc/1234/livedump
+
+Some things you can set:
+
+  sched_prio=<n> - Set the nice value for the forked process.  This is
+    useful to lower the priority so that the coredump doesn't interfere
+    with the rest of the system so much.
+
+  io_prio=<n> - Set the I/O priority, again useful for limiting the
+    impact of the coredump on the rest of the system.
+
+  oom_adj=<n> - Sets the OOM adjustment (like /proc/<pid>/oom_adj) for
+    the forked process.  This will let you allow the forked process to
+    be killed first in an OOM situation.
+
+  core_limit=<n>|unlimited - Set the core limit in the forked process.
+    It is a numerical value or "unlimited" as in "ulimit -c".
+

--- a/block/ioprio.c
+++ b/block/ioprio.c
@@ -146,7 +146,7 @@ free_uid:
 	return ret;
 }
 
-static int get_task_ioprio(struct task_struct *p)
+int get_task_ioprio(struct task_struct *p)
 {
 	int ret;
 

--- a/fs/coredump.c
+++ b/fs/coredump.c
@@ -536,7 +536,7 @@ static int umh_pipe_setup(struct subprocess_info *info, struct cred *new)
 	return err;
 }
 
-void do_coredump(const siginfo_t *siginfo)
+int do_coredump(const siginfo_t *siginfo)
 {
 	struct core_state core_state;
 	struct core_name cn;
@@ -772,7 +772,7 @@ fail_unlock:
 fail_creds:
 	put_cred(cred);
 fail:
-	return;
+	return retval;
 }
 
 /*

--- a/fs/proc/base.c
+++ b/fs/proc/base.c
@@ -94,6 +94,7 @@
 #include <linux/sched/stat.h>
 #include <linux/flex_array.h>
 #include <linux/posix-timers.h>
+#include <linux/livedump.h>
 #include <trace/events/oom.h>
 #include "internal.h"
 #include "fd.h"
@@ -2924,6 +2925,106 @@ static int proc_pid_patch_state(struct seq_file *m, struct pid_namespace *ns,
 }
 #endif /* CONFIG_LIVEPATCH */
 
+#ifdef CONFIG_LIVEDUMP
+struct livedump_proc_data {
+	char buf[500];
+	int pos;
+};
+
+static int livedump_open(struct inode *inode, struct file *file)
+{
+	struct livedump_proc_data *pdata;
+
+	pdata = kmalloc(sizeof(*pdata), GFP_KERNEL);
+	if (!pdata)
+		return -ENOMEM;
+	pdata->pos = 0;
+	file->private_data = pdata;
+	return 0;
+}
+
+static int livedump_release(struct inode *inode, struct file *file)
+{
+	struct livedump_proc_data *pdata = file->private_data;
+
+	kfree(pdata);
+	return 0;
+}
+
+static ssize_t livedump_write(struct file *file, const char __user *buf,
+			      size_t count, loff_t *ppos)
+{
+	struct livedump_proc_data *pdata = file->private_data;
+	struct livedump_param lparam;
+	int ret = 0;
+	char *curr, *next;
+
+	if (pdata->pos == -1) /* Only do this once per open. */
+		return count;
+
+	if (count + pdata->pos > sizeof(pdata->buf))
+		return -EFBIG;
+	if (copy_from_user(pdata->buf + pdata->pos, buf, count))
+		return -EFAULT;
+
+	curr = strchr(pdata->buf, '\n');
+	if (curr) {
+		struct task_struct *tsk = get_proc_task(file_inode(file));
+
+		pdata->pos = -1;
+
+		if (!tsk)
+			return -ESRCH;
+
+		init_livedump_param(&lparam);
+
+		*curr = '\0';
+		next = pdata->buf;
+		curr = strsep(&next, " \t");
+		for (; curr; curr = strsep(&next, " \t")) {
+			char *parm, *val, *end = "";
+
+			if (!*curr)
+				continue;
+			val = curr;
+			parm = strsep(&val, "=");
+			if (strcmp(parm, "sched_prio") == 0) {
+				lparam.sched_nice = simple_strtol(val, &end, 0);
+			} else if (strcmp(parm, "io_prio") == 0) {
+				lparam.io_prio = simple_strtol(val, &end, 0);
+			} else if (strcmp(parm, "oom_adj") == 0) {
+				lparam.oom_adj = simple_strtol(val, &end, 0);
+			} else if (strcmp(parm, "core_limit") == 0) {
+				lparam.core_limit_set = true;
+				if (strcmp(val, "unlimited") == 0)
+					lparam.core_limit = RLIM_INFINITY;
+				else
+					lparam.core_limit =
+						simple_strtoul(val, &end, 0);
+			} else
+				ret = -EINVAL;
+			if (*end)
+				ret = -EINVAL;
+		}
+
+		if (!ret)
+			ret = do_livedump(tsk, &lparam);
+
+		put_task_struct(tsk);
+
+		if (ret < 0)
+			return ret;
+	}
+	return count;
+}
+
+static const struct file_operations proc_livedump_operations = {
+	.open  = livedump_open,
+	.write = livedump_write,
+	.release = livedump_release,
+};
+#endif
+
 /*
  * Thread groups
  */
@@ -3024,6 +3125,9 @@ static const struct pid_entry tgid_base_stuff[] = {
 	REG("timerslack_ns", S_IRUGO|S_IWUGO, proc_pid_set_timerslack_ns_operations),
 #ifdef CONFIG_LIVEPATCH
 	ONE("patch_state",  S_IRUSR, proc_pid_patch_state),
+#endif
+#ifdef CONFIG_LIVEDUMP
+	REG("livedump",   S_IWUSR, proc_livedump_operations),
 #endif
 };
 

--- a/include/linux/compat.h
+++ b/include/linux/compat.h
@@ -531,6 +531,18 @@ int __compat_save_altstack(compat_stack_t __user *, unsigned long);
 		sas_ss_reset(t); \
 } while (0);
 
+#ifdef CONFIG_LIVEDUMP
+struct compat_livedump_param {
+	compat_int_t	sched_nice;
+	compat_int_t	io_prio;
+	compat_int_t	oom_adj;
+	compat_ulong_t	core_limit;
+};
+
+extern long compat_ptrace_livedump(struct task_struct *tsk,
+		struct compat_livedump_param __user *cparam);
+#endif
+
 /*
  * These syscall function prototypes are kept in the same order as
  * include/uapi/asm-generic/unistd.h. Deprecated or obsolete system calls

--- a/include/linux/coredump.h
+++ b/include/linux/coredump.h
@@ -17,9 +17,9 @@ extern int dump_emit(struct coredump_params *cprm, const void *addr, int nr);
 extern int dump_align(struct coredump_params *cprm, int align);
 extern void dump_truncate(struct coredump_params *cprm);
 #ifdef CONFIG_COREDUMP
-extern void do_coredump(const siginfo_t *siginfo);
+extern int do_coredump(const siginfo_t *siginfo);
 #else
-static inline void do_coredump(const siginfo_t *siginfo) {}
+static inline int do_coredump(const siginfo_t *siginfo) { return 0; }
 #endif
 
 #endif /* _LINUX_COREDUMP_H */

--- a/include/linux/ioprio.h
+++ b/include/linux/ioprio.h
@@ -76,5 +76,6 @@ static inline int task_nice_ioclass(struct task_struct *task)
 extern int ioprio_best(unsigned short aprio, unsigned short bprio);
 
 extern int set_task_ioprio(struct task_struct *task, int ioprio);
+extern int get_task_ioprio(struct task_struct *task);
 
 #endif

--- a/include/linux/livedump.h
+++ b/include/linux/livedump.h
@@ -358,7 +358,14 @@ static inline int livedump_check_signal_send(int sig, struct task_struct *tsk)
 	return 1;
 }
 
-extern void livedump_handle_signal(siginfo_t *);
+extern void __livedump_handle_signal(siginfo_t *info);
+
+static inline void livedump_handle_signal(siginfo_t *info)
+{
+	if (task_in_livedump(current))
+		__livedump_handle_signal(info);
+}
+
 extern int do_livedump(struct task_struct *tsk,
 		       struct livedump_param *param);
 

--- a/include/linux/livedump.h
+++ b/include/linux/livedump.h
@@ -1,0 +1,388 @@
+/*
+ * include/linux/livedump.h
+ *
+ * Live application dump datatype(s) and prototypes.
+ */
+
+#ifndef _LINUX_LIVEDUMP_H_
+#define _LINUX_LIVEDUMP_H_
+
+#include <asm/siginfo.h>
+#include <linux/sched.h>
+
+#ifdef CONFIG_LIVEDUMP
+#include <linux/kref.h>
+#include <linux/mutex.h>
+#include <linux/completion.h>
+#include <linux/swait.h>
+#include <linux/slab.h>
+#include <linux/pid.h>
+#include <asm/atomic.h>
+#include <asm/barrier.h>
+#include <linux/oom.h>
+#include <linux/ioprio.h>
+
+/* Dumping process stages.  */
+typedef enum {
+	LIVEDUMP_WAIT_STOP,	/* Waiting for all original threads to stop. */
+	LIVEDUMP_COPY_THREADS,
+	LIVEDUMP_PERFORM_DUMP,
+	LIVEDUMP_DUMP_COMPLETE
+} livedump_stage_t;
+
+struct livedump_param {
+	int sched_nice;
+	int io_prio;
+	int oom_adj;
+	bool core_limit_set;
+	unsigned long core_limit;
+};
+
+static inline void init_livedump_param(struct livedump_param *param)
+{
+	/* Make it ultra-low priority by default. */
+	param->sched_nice = 19;
+	param->io_prio = 7;
+	param->oom_adj = OOM_ADJUST_MAX;
+	param->core_limit_set = false;
+	param->core_limit = 0;
+}
+
+/*
+ * This is the dump context. It's created only once when dumping
+ * begins, and referenced from the task_struct of each clone involved
+ * in dumping.
+ */
+struct livedump_context {
+	/* Number of references to dump context. */
+	struct kref ref;
+
+	/* Number of original threads still in the dump process. */
+	struct kref orig_cloning;
+
+	/*
+	 * Namespace for the new PIDs.  We create a new namespace so
+	 * we can keep the pid numbers the same for the cloned
+	 * threads.
+	 */
+	struct pid_namespace *pid_ns;
+
+	/* The thread group leader of the task being dumped. */
+	struct task_struct *orig_leader;
+
+	/* The thread group leader of the cloned task. */
+	struct task_struct *dumped_leader;
+
+	/* Number of threads still in the process of being stopped. */
+	atomic_t nr_stop_remains;
+
+	/* Total number of threads that are currently stopped. */
+	atomic_t nr_stopped;
+
+	/* Tell the original leader that threads are stopped. */
+	struct completion stop_complete;
+
+	/*
+	 * Used by the threads to wait until everyone has stopped and the
+	 * dump thread leader is created.
+	 */
+	struct completion dump_leader_ready;
+
+	/* Tell the original leader that all threads have cloned. */
+	struct completion threads_cloned;
+
+	/* Tell the main thread that the clone process is done. */
+	struct completion orig_leader_complete;
+
+	/* Tell the main thread the dump is complete. */
+	struct completion dump_complete;
+
+	/* Parameters from the user. */
+	struct livedump_param param;
+
+	/* The stage of dump we are in. */
+	livedump_stage_t stage;
+
+	/* Return status for the dump. */
+	int status;
+};
+
+static inline void livedump_set_status(struct livedump_context *dump,
+				       long status)
+{
+	dump->status = status;
+}
+
+static inline int livedump_status(struct livedump_context *dump)
+{
+	return dump->status;
+}
+
+static inline void livedump_set_stage(struct livedump_context *dump,
+				      livedump_stage_t stage)
+{
+	dump->stage = stage;
+}
+
+static inline livedump_stage_t livedump_stage(struct livedump_context *dump)
+{
+	return dump->stage;
+}
+
+static inline void livedump_set_task_dump(struct task_struct *tsk,
+					  struct livedump_context *dump)
+{
+	tsk->livedump = dump;
+}
+
+static inline struct livedump_context *livedump_task_dump(struct task_struct *tsk)
+{
+	return tsk->livedump;
+}
+
+extern void livedump_ref_done(struct kref *ref);
+
+static inline struct livedump_context *get_dump(struct livedump_context *dump)
+{
+	kref_get(&dump->ref);
+	return dump;
+}
+
+static inline void put_dump(struct livedump_context *dump)
+{
+	kref_put(&dump->ref, livedump_ref_done);
+}
+
+static inline int __task_in_livedump(struct livedump_context *dump)
+{
+	/*
+	 * The dump variable for a thread group leader is set to
+	 * an error pointer when the task goes past the point
+	 * where it can be halted to complete a livedump.  That
+	 * way you can't start a livedump after that point.
+	 */
+	return !IS_ERR_OR_NULL(dump);
+}
+
+static inline int task_in_livedump(struct task_struct *tsk)
+{
+	return __task_in_livedump(livedump_task_dump(tsk));
+}
+
+static inline int task_in_livedump_stage(struct livedump_context *dump,
+					 livedump_stage_t check_stage)
+{
+	return __task_in_livedump(dump) ?
+		(livedump_stage(dump) == check_stage) : 0;
+}
+
+static inline int __livedump_task_is_clone_child(struct task_struct *tsk,
+						 struct livedump_context *dump)
+{
+	return (__task_in_livedump(dump) &&
+		tsk != tsk->group_leader &&
+		dump->dumped_leader == tsk->group_leader);
+}
+
+static inline int livedump_task_is_clone_child(struct task_struct *tsk)
+{
+	return __livedump_task_is_clone_child(tsk, livedump_task_dump(tsk));
+}
+
+static inline int __livedump_task_is_clone(struct task_struct *tsk,
+					   struct livedump_context *dump)
+{
+	return (__task_in_livedump(dump) &&
+		tsk->group_leader == dump->dumped_leader);
+}
+
+static inline int livedump_task_is_clone(struct task_struct *tsk)
+{
+	return __livedump_task_is_clone(tsk, livedump_task_dump(tsk));
+}
+
+static inline bool is_livedump_sigpending(struct task_struct *tsk)
+{
+	return tsk->livedump_sigpending;
+}
+
+static inline void clear_livedump_sigpending(struct task_struct *tsk)
+{
+	 tsk->livedump_sigpending = false;
+}
+
+static inline void __livedump_send_sig(struct task_struct *tsk, bool force)
+{
+	tsk->livedump_sigpending = true;
+	recalc_sigpending_and_wake(tsk);
+	if (force)
+		signal_wake_up(tsk, true);
+}
+
+static void livedump_setup_stop_task(struct task_struct *tsk,
+				     struct livedump_context *dump)
+{
+	atomic_inc(&dump->nr_stop_remains);
+	livedump_set_task_dump(tsk, get_dump(dump));
+}
+
+static inline void __livedump_signal_stop(struct task_struct *tsk,
+					  struct livedump_context *dump)
+{
+	assert_spin_locked(&tsk->sighand->siglock);
+	livedump_setup_stop_task(tsk, dump);
+	__livedump_send_sig(tsk, false);
+}
+
+static inline void livedump_stop_done(struct livedump_context *dump)
+{
+	if (atomic_dec_and_test(&dump->nr_stop_remains))
+		complete(&dump->stop_complete);
+}
+
+static inline void livedump_wait_for_stop_done(struct livedump_context *dump)
+{
+	int i = atomic_read(&dump->nr_stop_remains);
+
+	if (i > 0)
+		/* Only wait if we signalled some. */
+		wait_for_completion(&dump->stop_complete);
+}
+
+static inline void livedump_wake_stopped(struct livedump_context *dump)
+{
+	int i = atomic_read(&dump->nr_stopped);
+
+	if (i > 0) {
+		/*
+		 * Wake up all the waiting threads so they can clone,
+		 * or just exit if there was an error in the first
+		 * clone.
+		 */
+		for (; i >= 0; i--)
+			complete(&dump->dump_leader_ready);
+
+		wait_for_completion(&dump->threads_cloned);
+	}
+}
+
+/*
+ * Must be called with the sighand lock held.
+ */
+static inline void livedump_handle_exit(struct task_struct *tsk)
+{
+	struct livedump_context *dump = livedump_task_dump(tsk);
+
+	if (__task_in_livedump(dump)) {
+		/* Free the dump variable if necessary. */
+		livedump_set_task_dump(tsk, NULL);
+
+		if (dump->orig_leader == tsk) {
+			/*
+			 * The task group leader exited before it handled
+			 * the dump signal.  Just have the dump return
+			 * an error.
+			 */
+			livedump_wait_for_stop_done(dump);
+			livedump_wake_stopped(dump);
+			livedump_set_status(dump, -ESRCH);
+			complete(&dump->orig_leader_complete);
+		} else if (livedump_stage(dump) == LIVEDUMP_WAIT_STOP &&
+			   !livedump_task_is_clone(tsk)) {
+			/*
+			 * If livedumping and in WAIT_STOP state,
+			 * that means this thread is expected to stop
+			 * itself.  But at this point, it doesn't
+			 * matter, so just pretend like it was never
+			 * requested.
+			 */
+			livedump_stop_done(dump);
+		}
+
+		put_dump(dump);
+	}
+}
+
+extern int livedump_setup_clone(struct task_struct *clone,
+				struct livedump_context *dump,
+				unsigned long clone_flags);
+
+/*
+ * Called from the copy_process code with siglock held.
+ */
+static inline int livedump_check_tsk_copy(struct task_struct *tsk,
+					  unsigned long clone_flags)
+{
+	int ret = 0;
+	struct livedump_context *dump = livedump_task_dump(current);
+
+	if (task_in_livedump_stage(dump, LIVEDUMP_WAIT_STOP) &&
+	    !(clone_flags & CLONE_LIVEDUMP) && (clone_flags & CLONE_THREAD)) {
+		/*
+		 * Current task being livedumped and the dump process
+		 * is in WAIT_STOP stage. Make sure the new thread
+		 * is livedumped, too.
+		 */
+		__livedump_signal_stop(tsk, dump);
+	} else if (clone_flags & CLONE_LIVEDUMP) {
+		ret = livedump_setup_clone(tsk, dump, clone_flags);
+	}
+
+	return ret;
+}
+
+/*
+ * Validates that a livedump clone thread is allowed to receive a signal.
+ * Used to keep other nefarious processes from messing up a livedump.
+ */
+static inline int livedump_check_signal_send(int sig, struct task_struct *tsk)
+{
+	struct livedump_context *dump = livedump_task_dump(tsk);
+
+	if (!__task_in_livedump(dump))
+		return 1;
+
+	if (__livedump_task_is_clone_child(tsk, dump)) {
+		/*
+		 * The livedump clone children (not clone thread group
+		 * leader) can only receive signals from the clone
+		 * thread group leader.  Just ignore everything else.
+		 */
+		if (current != dump->dumped_leader)
+			return 0;
+	} else if (__livedump_task_is_clone(tsk, dump)) {
+		/* The clone thread group leader ignores all signals. */
+		return 0;
+	}
+
+	return 1;
+}
+
+extern void livedump_handle_signal(siginfo_t *);
+extern int do_livedump(struct task_struct *tsk,
+		       struct livedump_param *param);
+
+#else
+
+struct livedump_context;
+
+static inline void livedump_set_task_dump(struct task_struct *tsk,
+					  struct livedump_context *dump) { }
+static inline void livedump_handle_signal(siginfo_t *info) { }
+static inline int task_in_livedump(struct task_struct *tsk) { return 0; }
+static inline void livedump_handle_exit(struct task_struct *tsk) { }
+static inline int livedump_check_tsk_copy(struct task_struct *tsk,
+				unsigned long clone_flags) { return 0; }
+static inline void livedump_check_tsk_exit(struct task_struct *tsk) { }
+static inline int livedump_task_is_clone(struct task_struct *tsk) { return 0; }
+static inline int livedump_task_is_clone_child(struct task_struct *tsk)
+{ return 0; }
+static inline int livedump_check_signal_send(int sig, struct task_struct *tsk)
+{ return 1; }
+static inline bool is_livedump_sigpending(struct task_struct *tsk)
+{ return 0; }
+static inline void clear_livedump_sigpending(struct task_struct *tsk) { }
+
+#endif /* CONFIG_LIVEDUMP */
+
+#endif /* _LINUX_LIVEDUMP_H_ */

--- a/include/linux/pid.h
+++ b/include/linux/pid.h
@@ -118,6 +118,7 @@ extern struct pid *find_get_pid(int nr);
 extern struct pid *find_ge_pid(int nr, struct pid_namespace *);
 int next_pidmap(struct pid_namespace *pid_ns, unsigned int last);
 
+extern struct pid *alloc_pid_nr(struct pid_namespace *ns, int use_pid);
 extern struct pid *alloc_pid(struct pid_namespace *ns);
 extern void free_pid(struct pid *pid);
 extern void disable_pid_allocation(struct pid_namespace *ns);

--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -37,6 +37,9 @@ struct cfs_rq;
 struct fs_struct;
 struct futex_pi_state;
 struct io_context;
+#ifdef CONFIG_LIVEDUMP
+struct livedump_context;
+#endif
 struct mempolicy;
 struct nameidata;
 struct nsproxy;
@@ -1166,6 +1169,10 @@ struct task_struct {
 #ifdef CONFIG_SECURITY
 	/* Used by LSM modules for access restriction: */
 	void				*security;
+#endif
+#ifdef CONFIG_LIVEDUMP
+	struct livedump_context		*livedump;
+	bool				livedump_sigpending;
 #endif
 
 	/*

--- a/include/linux/sched/task.h
+++ b/include/linux/sched/task.h
@@ -73,6 +73,9 @@ extern void exit_itimers(struct signal_struct *);
 
 extern long _do_fork(unsigned long, unsigned long, unsigned long, int __user *, int __user *, unsigned long);
 extern long do_fork(unsigned long, unsigned long, unsigned long, int __user *, int __user *);
+extern struct task_struct *copy_process(unsigned long, unsigned long,
+					unsigned long, int __user *,
+					struct pid *, int, unsigned long, int);
 struct task_struct *fork_idle(int);
 extern pid_t kernel_thread(int (*fn)(void *), void *arg, unsigned long flags);
 extern long kernel_wait4(pid_t, int *, int, struct rusage *);

--- a/include/uapi/linux/ptrace.h
+++ b/include/uapi/linux/ptrace.h
@@ -29,6 +29,7 @@
 #define PTRACE_GETEVENTMSG	0x4201
 #define PTRACE_GETSIGINFO	0x4202
 #define PTRACE_SETSIGINFO	0x4203
+#define PTRACE_LIVEDUMP 	0x4221
 
 /*
  * Generic ptrace interface that exports the architecture specific regsets

--- a/include/uapi/linux/sched.h
+++ b/include/uapi/linux/sched.h
@@ -10,6 +10,7 @@
 #define CLONE_FS	0x00000200	/* set if fs info shared between processes */
 #define CLONE_FILES	0x00000400	/* set if open files shared between processes */
 #define CLONE_SIGHAND	0x00000800	/* set if signal handlers and blocked signals shared */
+#define CLONE_LIVEDUMP	0x00001000	/* set if cloned for a live dump */
 #define CLONE_PTRACE	0x00002000	/* set if we want to let tracing continue on the child too */
 #define CLONE_VFORK	0x00004000	/* set if the parent wants the child to wake it up on mm_release */
 #define CLONE_PARENT	0x00008000	/* set if we want to have the same parent as the cloner */

--- a/init/Kconfig
+++ b/init/Kconfig
@@ -1205,6 +1205,15 @@ config ELF_CORE
 	help
 	  Enable support for generating core dumps. Disabling saves about 4k.
 
+config LIVEDUMP
+	depends on COREDUMP
+	select PID_NS
+	default n
+	bool "Enable Live Application Dump"
+	help
+	  Enable support for live application dump, i.e. the capability to
+	  drop core files from the running process without (substantial)
+	  interruption of it.
 
 config PCSPKR_PLATFORM
 	bool "Enable PC-Speaker support" if EXPERT

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -114,6 +114,8 @@ obj-$(CONFIG_TORTURE_TEST) += torture.o
 
 obj-$(CONFIG_HAS_IOMEM) += memremap.o
 
+obj-$(CONFIG_LIVEDUMP) += livedump.o
+
 $(obj)/configs.o: $(obj)/config_data.h
 
 targets += config_data.gz

--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -62,6 +62,7 @@
 #include <linux/random.h>
 #include <linux/rcuwait.h>
 #include <linux/compat.h>
+#include <linux/livedump.h>
 
 #include <linux/uaccess.h>
 #include <asm/unistd.h>
@@ -98,6 +99,8 @@ static void __exit_signal(struct task_struct *tsk)
 	sighand = rcu_dereference_check(tsk->sighand,
 					lockdep_tasklist_lock_is_held());
 	spin_lock(&sighand->siglock);
+
+	livedump_handle_exit(tsk);
 
 #ifdef CONFIG_POSIX_TIMERS
 	posix_cpu_timers_exit(tsk);
@@ -192,7 +195,9 @@ repeat:
 	atomic_dec(&__task_cred(p)->user->processes);
 	rcu_read_unlock();
 
-	proc_flush_task(p);
+	if (!livedump_task_is_clone(p))
+		/* livedump clones don't set up proc. */
+		proc_flush_task(p);
 
 	write_lock_irq(&tasklist_lock);
 	ptrace_release_task(p);
@@ -714,6 +719,9 @@ static void exit_notify(struct task_struct *tsk, int group_dead)
 				!ptrace_reparented(tsk) ?
 			tsk->exit_signal : SIGCHLD;
 		autoreap = do_notify_parent(tsk, sig);
+	} else if (livedump_task_is_clone_child(tsk)) {
+		/* Always autoreap livedumped cloned threads. */
+		autoreap = true;
 	} else if (thread_group_leader(tsk)) {
 		autoreap = thread_group_empty(tsk) &&
 			do_notify_parent(tsk, tsk->exit_signal);
@@ -947,7 +955,6 @@ do_group_exit(int exit_code)
 	struct signal_struct *sig = current->signal;
 
 	BUG_ON(exit_code & 0x80); /* core dumps don't get here */
-
 	if (signal_group_exit(sig))
 		exit_code = sig->group_exit_code;
 	else if (!thread_group_empty(current)) {

--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -1574,13 +1574,14 @@ __latent_entropy struct task_struct *copy_process(
 					unsigned long stack_start,
 					unsigned long stack_size,
 					int __user *child_tidptr,
-					struct pid *pid,
+					struct pid *usepid,
 					int trace,
 					unsigned long tls,
 					int node)
 {
 	int retval;
 	struct task_struct *p;
+	struct pid *pid;
 
 	/*
 	 * Don't allow sharing the root directory with processes in a different
@@ -1804,7 +1805,9 @@ __latent_entropy struct task_struct *copy_process(
 	if (retval)
 		goto bad_fork_cleanup_io;
 
-	if (pid != &init_struct_pid) {
+	if (usepid) {
+		pid = usepid;
+	} else {
 		pid = alloc_pid(p->nsproxy->pid_ns_for_children);
 		if (IS_ERR(pid)) {
 			retval = PTR_ERR(pid);
@@ -1978,7 +1981,7 @@ bad_fork_cancel_cgroup:
 	cgroup_cancel_fork(p);
 bad_fork_free_pid:
 	cgroup_threadgroup_change_end(current);
-	if (pid != &init_struct_pid)
+	if (!usepid)
 		free_pid(pid);
 bad_fork_cleanup_thread:
 	exit_thread(p);

--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -1945,9 +1945,9 @@ __latent_entropy struct task_struct *copy_process(
 			attach_pid(p, PIDTYPE_SID);
 			__this_cpu_inc(process_counts);
 		} else {
-			current->signal->nr_threads++;
-			atomic_inc(&current->signal->live);
-			atomic_inc(&current->signal->sigcnt);
+			p->signal->nr_threads++;
+			atomic_inc(&p->signal->live);
+			atomic_inc(&p->signal->sigcnt);
 			list_add_tail_rcu(&p->thread_group,
 					  &p->group_leader->thread_group);
 			list_add_tail_rcu(&p->thread_node,

--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -91,6 +91,7 @@
 #include <linux/kcov.h>
 #include <linux/livepatch.h>
 #include <linux/thread_info.h>
+#include <linux/livedump.h>
 
 #include <asm/pgtable.h>
 #include <asm/pgalloc.h>
@@ -1843,6 +1844,8 @@ __latent_entropy struct task_struct *copy_process(
 #endif
 	clear_all_latency_tracing(p);
 
+	livedump_set_task_dump(p, NULL);
+
 	/* ok, now we should be set up.. */
 	p->pid = pid_nr(pid);
 	if (clone_flags & CLONE_THREAD) {
@@ -1919,6 +1922,10 @@ __latent_entropy struct task_struct *copy_process(
 		retval = -ENOMEM;
 		goto bad_fork_cancel_cgroup;
 	}
+
+	retval = livedump_check_tsk_copy(p, clone_flags);
+	if (retval)
+		goto bad_fork_cancel_cgroup;
 
 	if (likely(p->pid)) {
 		ptrace_init_task(p, (clone_flags & CLONE_PTRACE) || trace);
@@ -2069,6 +2076,11 @@ long _do_fork(unsigned long clone_flags,
 	struct task_struct *p;
 	int trace = 0;
 	long nr;
+
+#ifdef CONFIG_LIVEDUMP
+	if (clone_flags & CLONE_LIVEDUMP)
+		return -EINVAL;
+#endif
 
 	/*
 	 * Determine whether and which event to report to ptracer.  When

--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -1569,7 +1569,7 @@ static inline void rcu_copy_process(struct task_struct *p)
  * parts of the process environment (as per the clone
  * flags). The actual kick-off is left to the caller.
  */
-static __latent_entropy struct task_struct *copy_process(
+__latent_entropy struct task_struct *copy_process(
 					unsigned long clone_flags,
 					unsigned long stack_start,
 					unsigned long stack_size,

--- a/kernel/livedump.c
+++ b/kernel/livedump.c
@@ -33,7 +33,7 @@
  */
 
 #include <linux/kernel.h>
-#include <linux/sched.h>
+#include <linux/sched/task_stack.h>
 #include <linux/sched/mm.h>
 #include <linux/signal.h>
 #include <linux/file.h>

--- a/kernel/livedump.c
+++ b/kernel/livedump.c
@@ -1,0 +1,488 @@
+/*
+ * kernel/livedump.c
+ *
+ * Core of live application dump.
+ *
+ * Actual dumping is initiated by sending SIGKILL to the thread
+ * group leader, which is done by ptrace(PT_LIVEDUMP, ...). The
+ * rest is signal-driven too, and performed by appropriate calls
+ * from get_signal_to_deliver().
+ *
+ * The various interactions are rather convoluted, but here's the big
+ * picture.  In the following, O is the requesting process, T is the
+ * task leader being cloned (orig_leader), t is a thread being cloned,
+ * C is the clone leader (dumped_leader) and c is a clone thread.
+ *
+ *
+ * O: allocate dump
+ * O: T->livedump = dump
+ * O: signal(T)
+ * O: wait for original thread leader complete
+ * T: for each (t) t->livedump = dump, signal(t)
+ * T: wait for all threads stopped
+ * T: C = clone(T) (also clones mm)
+ * T: for each (t) wake up
+ * t: c = clone(c) (Copies mm from C)
+ * t: if (I am last clone) tell T clone is complete
+ * t: Return to normal operation
+ * T: Tell O that the clone is ready
+ * T: Return to normal operation
+ * O: Wake up O
+ * O: wait for dump_complete
+ * C: dump core
+ * C: wake O with dump_complete
+ * C: exit
+ * O: Return status
+ */
+
+#include <linux/kernel.h>
+#include <linux/sched.h>
+#include <linux/sched/mm.h>
+#include <linux/signal.h>
+#include <linux/file.h>
+#include <linux/err.h>
+#include <linux/binfmts.h>
+#include <linux/mutex.h>
+#include <linux/livedump.h>
+#include <linux/ioprio.h>
+#include <linux/coredump.h>
+#include <linux/kthread.h>
+#include <linux/ptrace.h>
+
+#include <asm/mmu_context.h>
+#include <asm/processor.h>
+
+int livedump_setup_clone(struct task_struct *clone,
+			 struct livedump_context *dump,
+			 unsigned long clone_flags)
+{
+	struct livedump_param *param = &dump->param;
+	int err, prio;
+
+	clone->state = TASK_STOPPED;
+
+	/*
+	 * Make sure we fall into the signal handler when we exit.
+	 */
+	set_tsk_thread_flag(clone, TIF_SIGPENDING);
+	clone->livedump_sigpending = true;
+
+	/*
+	 * The clone is done with all signals blocked so there is no
+	 * error caused by a signal pending in the original thread.
+	 * But SIGKILL is needed to take the coredump, so re-add it.
+	 */
+	sigdelset(&clone->blocked, SIGKILL);
+
+	/*
+	 * Switch over to the dumper leader's mm, group, signal, and sighand
+	 * structures.
+	 */
+	if (clone_flags & CLONE_THREAD) {
+		struct mm_struct *oldmm = clone->mm;
+		struct sighand_struct *oldsighand = clone->sighand;
+
+		atomic_inc(&dump->dumped_leader->mm->mm_users);
+		clone->mm = dump->dumped_leader->mm;
+		clone->active_mm = dump->dumped_leader->mm;
+		mmput(oldmm);
+
+		clone->group_leader = dump->dumped_leader;
+
+		clone->signal = dump->dumped_leader->signal;
+
+		atomic_inc(&dump->dumped_leader->sighand->count);
+		clone->sighand = dump->dumped_leader->sighand;
+		__cleanup_sighand(oldsighand);
+
+		livedump_set_task_dump(clone, get_dump(dump));
+	}
+
+	set_user_nice(clone, param->sched_nice);
+
+	/* Clone will have inherited I/O scheduling class, but new priority. */
+	prio = get_task_ioprio(clone);
+	if (prio < 0)
+		return prio;
+	err = set_task_ioprio(clone, IOPRIO_PRIO_VALUE
+			      (IOPRIO_PRIO_CLASS(prio), param->io_prio));
+	if (err)
+		return err;
+
+	clone->signal->oom_score_adj = param->oom_adj;
+
+	/* This is for the leader only, as sys_setrlimit() does. */
+	if (!(clone_flags & CLONE_THREAD) && param->core_limit_set) {
+		clone->signal->rlim[RLIMIT_CORE].rlim_cur = param->core_limit;
+		clone->signal->rlim[RLIMIT_CORE].rlim_max = param->core_limit;
+	}
+
+	return 0;
+}
+
+static void livedump_block_signals(sigset_t *saveset)
+{
+	/* Save original blocked set, block everything. */
+	spin_lock_irq(&current->sighand->siglock);
+	*saveset = current->blocked;
+	sigfillset(&current->blocked);
+	recalc_sigpending();
+	spin_unlock_irq(&current->sighand->siglock);
+}
+
+static void livedump_unblock_signals(sigset_t *restoreset)
+{
+        /* Restore original blocking set. */
+	spin_lock_irq(&current->sighand->siglock);
+	current->blocked = *restoreset;
+	recalc_sigpending();
+	spin_unlock_irq(&current->sighand->siglock);
+}
+
+/*
+ * Copy current task_struct, make clone suitable for dumping.
+ */
+static struct task_struct *livedump_clone(struct livedump_context *dump,
+					  unsigned long clone_flags)
+{
+	/* We use the same pid as the cloned thread. */
+	struct pid *pid, *opid = get_task_pid(current, PIDTYPE_PID);
+	struct task_struct *clone;
+	sigset_t saveset;
+
+	pid = alloc_pid_nr(dump->pid_ns, pid_vnr(opid));
+	put_pid(opid);
+	if (IS_ERR(pid))
+		return ERR_PTR(PTR_ERR(pid));
+
+	/*
+	 * copy_process() will error if any signals are pending for the
+	 * thread.  So make sure no signals are pending.
+	 */
+	livedump_block_signals(&saveset);
+	clone = copy_process(CLONE_LIVEDUMP | clone_flags,
+			     KSTK_ESP(current), 0, NULL, pid, 0, 0,
+			     NUMA_NO_NODE);
+	livedump_unblock_signals(&saveset);
+	if (IS_ERR(clone))
+		free_pid(pid);
+
+	return clone;
+}
+
+/*
+ * Clone one thread, force the new thread group leader
+ * to perform the dump if we're the last thread cloned.
+ */
+static void livedump_clone_leader(struct livedump_context *dump)
+{
+	struct task_struct *clone;
+
+	livedump_wait_for_stop_done(dump);
+	livedump_set_stage(dump, LIVEDUMP_COPY_THREADS);
+
+	/* Now create the clone leader. */
+	clone = livedump_clone(dump, CLONE_PARENT);
+	if (IS_ERR(clone)) {
+		livedump_set_status(dump, PTR_ERR(clone));
+	} else {
+		dump->dumped_leader = clone;
+		livedump_set_task_dump(clone, get_dump(dump));
+	}
+
+	livedump_wake_stopped(dump);
+
+	if (IS_ERR(clone)) {
+		livedump_set_task_dump(current, NULL);
+		complete(&dump->orig_leader_complete);
+		put_dump(dump);
+		return;
+	}
+
+	/*
+	 * Wait for all threads to complete before setting our dump
+	 * variable to NULL, this avoids starting another dump before
+	 * all the threads in this process are ready.
+	 */
+	dump->orig_leader = NULL;
+	livedump_set_task_dump(current, NULL);
+	put_dump(dump);
+
+	complete(&dump->orig_leader_complete);
+}
+
+static void livedump_clone_child(struct livedump_context *dump)
+{
+	struct task_struct *clone;
+
+	clone = livedump_clone(dump,
+			       CLONE_THREAD | CLONE_SIGHAND | CLONE_VM);
+	if (IS_ERR(clone)) {
+		/*
+		 * Save first error we've encountered. Other threads
+		 * may fail to clone themselves too, but their errors
+		 * will be discarded.
+		 */
+		if (!livedump_status(dump))
+			livedump_set_status(dump, PTR_ERR(clone));
+	}
+}
+
+static inline void livedump_thread_clone_done(struct livedump_context *dump)
+{
+	if (atomic_dec_and_test(&dump->nr_stopped))
+		complete(&dump->threads_cloned);
+}
+
+/*
+ * A thread that needs to be cloned needs to stop.
+ */
+static void livedump_handle_stop(struct livedump_context *dump)
+{
+	atomic_inc(&dump->nr_stopped);
+	livedump_stop_done(dump);
+
+	wait_for_completion(&dump->dump_leader_ready);
+	if (dump->dumped_leader)
+		/* Don't clone unless first clone succeeded. */
+		livedump_clone_child(dump);
+
+	livedump_set_task_dump(current, NULL);
+	livedump_thread_clone_done(dump);
+	put_dump(dump);
+
+	/* The thread is now free to run. */
+}
+
+/*
+ * Complete the dump in the cloned leader. Core file is dumped only if
+ * dump->status is 0 before dumping, i.e. there was no errors on the
+ * previous stages.
+ */
+static void livedump_perform_dump(siginfo_t *info,
+				  struct livedump_context *dump)
+{
+	sigset_t blocked;
+	long status;
+
+	current->flags |= PF_SIGNALED;
+
+	if (!livedump_status(dump)) {
+		/*
+		 * Everything looks valid, may dump core. All signals
+		 * are blocked to avoid magic -ERESTARTSYS errors
+		 * comes due to I/O via NFS.
+		 */
+		sigfillset(&blocked);
+		sigprocmask(SIG_BLOCK, &blocked, NULL);
+		flush_signals(current);
+
+		status = do_coredump(info);
+
+		livedump_set_stage(dump, LIVEDUMP_DUMP_COMPLETE);
+		livedump_set_status(dump, status);
+	}
+	complete(&dump->dump_complete);
+	do_group_exit(SIGKILL);
+	/* NOTREACHED */
+}
+
+void livedump_handle_signal(siginfo_t *info)
+{
+	struct livedump_context *dump = livedump_task_dump(current);
+
+	if (!__task_in_livedump(dump))
+		return;
+
+	if (livedump_task_is_clone_child(current)) {
+		/*
+		 * Clone children are never allowed to run, so trap them
+		 * here until they are killed.
+		 */
+		schedule_timeout_killable(1);
+		current->livedump_sigpending = true;
+		recalc_sigpending();
+		return;
+	}
+
+	switch (livedump_stage(dump)) {
+	case LIVEDUMP_WAIT_STOP:
+		if (current == dump->orig_leader)
+			livedump_clone_leader(dump);
+		else
+			livedump_handle_stop(dump);
+		break;
+	case LIVEDUMP_PERFORM_DUMP:
+		BUG_ON(!__livedump_task_is_clone(current, dump) ||
+		       !thread_group_leader(current));
+		livedump_perform_dump(info, dump);
+		/* NOTREACHED */
+		BUG();
+		break;
+	default:
+		BUG();
+	}
+}
+
+void livedump_ref_done(struct kref *ref)
+{
+	struct livedump_context *dump = container_of(ref,
+						     struct livedump_context,
+						     ref);
+
+	put_pid_ns(dump->pid_ns);
+	kfree(dump);
+}
+
+/*
+ * Signal all threads in the process except the thread passed in and
+ * the original leader thread.
+ */
+static void livedump_sig_threads(struct livedump_context *dump,
+				 struct task_struct *t)
+{
+	struct task_struct *p;
+
+	/*
+	 * Request all the other threads to stop.  siglock protects
+	 * the thread list.
+	 */
+	spin_lock_irq(&t->sighand->siglock);
+	for (p = next_thread(t); p != t; p = next_thread(p)) {
+		if (p != dump->orig_leader)
+			__livedump_signal_stop(p, dump);
+	}
+	spin_unlock_irq(&t->sighand->siglock);
+}
+
+static inline void livedump_signal_leader(struct task_struct *tsk,
+					  bool force)
+{
+	spin_lock_irq(&tsk->sighand->siglock);
+	__livedump_send_sig(tsk, force);
+	spin_unlock_irq(&tsk->sighand->siglock);
+}
+
+int do_livedump(struct task_struct *tsk, struct livedump_param *param)
+{
+	int ret = 0;
+	struct livedump_context *dump;
+	struct task_struct *orig_leader;
+
+	if (param->sched_nice < -20 ||
+			param->sched_nice > 19 ||
+			param->io_prio < 0 ||
+			param->io_prio >= IOPRIO_BE_NR ||
+			param->oom_adj < OOM_DISABLE ||
+			param->oom_adj > OOM_ADJUST_MAX ||
+			param->core_limit > RLIM_INFINITY)
+		return -EINVAL;
+	else if ((param->sched_nice < 0 && !capable(CAP_SYS_NICE)) ||
+			(param->core_limit && !capable(CAP_SYS_RESOURCE)))
+		return -EPERM;
+
+	dump = kmalloc(sizeof(*dump), GFP_KERNEL);
+	if (!dump)
+		return -ENOMEM;
+
+	dump->param = *param;
+	kref_init(&dump->ref);
+	dump->dumped_leader = NULL;
+
+	/* Initialize the rest of livedump context. */
+	livedump_set_status(dump, 0);
+	livedump_set_stage(dump, LIVEDUMP_WAIT_STOP);
+	init_completion(&dump->stop_complete);
+	init_completion(&dump->dump_leader_ready);
+	init_completion(&dump->threads_cloned);
+	init_completion(&dump->orig_leader_complete);
+	init_completion(&dump->dump_complete);
+	atomic_set(&dump->nr_stop_remains, 0);
+	atomic_set(&dump->nr_stopped, 0);
+
+	/*
+	 * The parent PID and user namespace for the new
+	 * threads aren't important, we just need something
+	 * there to make the code work.
+	 */
+	dump->pid_ns = copy_pid_ns(CLONE_NEWPID, &init_user_ns,
+				   &init_pid_ns);
+	if (IS_ERR(dump->pid_ns)) {
+		ret = PTR_ERR(dump->pid_ns);
+		goto out_err;
+	}
+
+	/*
+	 * Do not dump a task being ptraced, kernel thread, or task
+	 * which is exiting or handling fatal signal.
+	 */
+	write_lock_irq(&tasklist_lock);
+	orig_leader = tsk->group_leader;
+	dump->orig_leader = orig_leader;
+	if (orig_leader->ptrace & PT_PTRACED ||
+            !orig_leader->mm ||
+            orig_leader->flags & PF_SIGNALED ||
+            orig_leader->signal->flags & SIGNAL_GROUP_EXIT)
+                ret = -EINVAL;
+	else if (livedump_task_dump(orig_leader))
+		/* leader is already in a dump or exiting. */
+		ret = -EINPROGRESS;
+	else
+		livedump_set_task_dump(orig_leader, get_dump(dump));
+
+	write_unlock_irq(&tasklist_lock);
+	if (ret)
+		goto out_err;
+
+	if (current->group_leader == orig_leader) {
+		livedump_sig_threads(dump, current);
+
+		if (current == orig_leader) {
+			/*
+			 * We are the original leader, just start the
+			 * process directly.
+			 */
+			livedump_clone_leader(dump);
+		} else {
+			/*
+			 * We are a non-leader of the original process,
+			 * pretend like we were signaled and wake the
+			 * leader.
+			 */
+			livedump_setup_stop_task(current, dump);
+			livedump_signal_leader(orig_leader, false);
+			livedump_handle_stop(dump);
+		}
+	} else {
+		livedump_sig_threads(dump, orig_leader);
+
+		/* Tell the leader to start the dump. */
+		livedump_signal_leader(orig_leader, false);
+	}
+
+	wait_for_completion(&dump->orig_leader_complete);
+	ret = livedump_status(dump);
+
+	if (dump->dumped_leader) {
+		/*
+		 * If the dumped leader was created, make sure to wake
+		 * it up no matter what.
+		 */
+		livedump_set_stage(dump, LIVEDUMP_PERFORM_DUMP);
+		livedump_signal_leader(dump->dumped_leader, true);
+	}
+
+	if (!ret) {
+		/* Wait for the dumped leader to save the core. */
+		wait_for_completion(&dump->dump_complete);
+		ret = livedump_status(dump);
+	}
+
+	put_dump(dump);
+
+	return ret;
+
+out_err:
+	kfree(dump);
+	return ret;
+}

--- a/kernel/livedump.c
+++ b/kernel/livedump.c
@@ -293,12 +293,9 @@ static void livedump_perform_dump(siginfo_t *info,
 /*
  * Called from get_signal()
  */
-void livedump_handle_signal(siginfo_t *info)
+void __livedump_handle_signal(siginfo_t *info)
 {
 	struct livedump_context *dump = livedump_task_dump(current);
-
-	if (!__task_in_livedump(dump))
-		return;
 
 	if (livedump_task_is_clone_child(current)) {
 		/*

--- a/kernel/pid.c
+++ b/kernel/pid.c
@@ -156,7 +156,7 @@ void free_pid(struct pid *pid)
 	call_rcu(&pid->rcu, delayed_put_pid);
 }
 
-struct pid *alloc_pid(struct pid_namespace *ns)
+struct pid *alloc_pid_nr(struct pid_namespace *ns, int use_pid)
 {
 	struct pid *pid;
 	enum pid_type type;
@@ -173,7 +173,7 @@ struct pid *alloc_pid(struct pid_namespace *ns)
 	pid->level = ns->level;
 
 	for (i = ns->level; i >= 0; i--) {
-		int pid_min = 1;
+		int pid_min = 1, local_pid_max = pid_max;
 
 		idr_preload(GFP_KERNEL);
 		spin_lock_irq(&pidmap_lock);
@@ -185,12 +185,22 @@ struct pid *alloc_pid(struct pid_namespace *ns)
 		if (idr_get_cursor(&tmp->idr) > RESERVED_PIDS)
 			pid_min = RESERVED_PIDS;
 
+		if (use_pid) {
+			if (use_pid < pid_min || use_pid >= pid_max) {
+				retval = -EINVAL;
+				goto out_free;
+			}
+
+			pid_min = use_pid;
+			local_pid_max = use_pid + 1;
+		}
+
 		/*
 		 * Store a null pointer so find_pid_ns does not find
 		 * a partially initialized PID (see below).
 		 */
 		nr = idr_alloc_cyclic(&tmp->idr, NULL, pid_min,
-				      pid_max, GFP_ATOMIC);
+				      local_pid_max, GFP_ATOMIC);
 		spin_unlock_irq(&pidmap_lock);
 		idr_preload_end();
 
@@ -198,6 +208,8 @@ struct pid *alloc_pid(struct pid_namespace *ns)
 			retval = nr;
 			goto out_free;
 		}
+		BUG_ON(use_pid && use_pid != nr);
+		use_pid = 0; /* Only used specified pid on the first level. */
 
 		pid->numbers[i].nr = nr;
 		pid->numbers[i].ns = tmp;
@@ -244,6 +256,11 @@ out_free:
 
 	kmem_cache_free(ns->pid_cachep, pid);
 	return ERR_PTR(retval);
+}
+
+struct pid *alloc_pid(struct pid_namespace *ns)
+{
+	return alloc_pid_nr(ns, 0);
 }
 
 void disable_pid_allocation(struct pid_namespace *ns)

--- a/kernel/ptrace.c
+++ b/kernel/ptrace.c
@@ -29,6 +29,7 @@
 #include <linux/hw_breakpoint.h>
 #include <linux/cn_proc.h>
 #include <linux/compat.h>
+#include <linux/livedump.h>
 
 /*
  * Access another process' address space via ptrace.
@@ -1107,6 +1108,39 @@ int ptrace_request(struct task_struct *child, long request,
 #define arch_ptrace_attach(child)	do { } while (0)
 #endif
 
+#ifdef CONFIG_LIVEDUMP
+long ptrace_livedump(struct task_struct *tsk,
+		     struct livedump_param __user *param)
+{
+	int ret;
+	struct livedump_param lparam;
+	struct task_struct *leader;
+
+	if (param) {
+		if (copy_from_user(&lparam, param, sizeof(lparam)))
+			return -EFAULT;
+	} else {
+		init_livedump_param(&lparam);
+	}
+
+	rcu_read_lock();
+	leader = tsk->group_leader;
+	BUG_ON(!leader);
+	get_task_struct(leader);
+	rcu_read_unlock();
+
+	/* FIXME - better security check here ? */
+	if (!ptrace_check_attach(leader, 0))
+		ret = -EPERM;
+	else
+		ret = do_livedump(leader, &lparam);
+
+	put_task_struct(leader);
+
+	return ret;
+}
+#endif /* CONFIG_LIVEDUMP */
+
 SYSCALL_DEFINE4(ptrace, long, request, long, pid, unsigned long, addr,
 		unsigned long, data)
 {
@@ -1125,6 +1159,16 @@ SYSCALL_DEFINE4(ptrace, long, request, long, pid, unsigned long, addr,
 		ret = -ESRCH;
 		goto out;
 	}
+
+	if (request == PTRACE_LIVEDUMP) {
+#ifdef CONFIG_LIVEDUMP
+		ret = ptrace_livedump
+		  (child, (struct livedump_param __user *)data);
+#else
+		ret = -ENOSYS;
+#endif
+		goto out_put_task_struct;
+        }
 
 	if (request == PTRACE_ATTACH || request == PTRACE_SEIZE) {
 		ret = ptrace_attach(child, request, addr, data);
@@ -1175,6 +1219,41 @@ int generic_ptrace_pokedata(struct task_struct *tsk, unsigned long addr,
 }
 
 #if defined CONFIG_COMPAT
+
+#ifdef CONFIG_LIVEDUMP
+static inline long
+copy_livedump_param_from_user32(struct livedump_param *to,
+				struct compat_livedump_param __user  *from)
+{
+	long err;
+
+	if (!access_ok (VERIFY_READ, from, sizeof(struct compat_livedump_param)))
+		return -EFAULT;
+
+	err = __get_user(to->sched_nice, &from->sched_nice);
+	err |= __get_user(to->io_prio, &from->io_prio);
+	err |= __get_user(to->oom_adj, &from->oom_adj);
+	err |= __get_user(to->core_limit, &from->core_limit);
+
+	return err;
+}
+
+long compat_ptrace_livedump(struct task_struct *tsk,
+			    struct compat_livedump_param __user *cparam)
+{
+	struct livedump_param __user tmp, *param;
+
+	if (cparam) {
+		param = compat_alloc_user_space(sizeof(struct livedump_param));
+		if (copy_livedump_param_from_user32(&tmp, cparam))
+			return -EFAULT;
+		if (copy_to_user(param, &tmp, sizeof(struct livedump_param)))
+			return -EFAULT;
+	} else
+		param = NULL;
+	return ptrace_livedump(tsk, param);
+}
+#endif	/* CONFIG_LIVEDUMP */
 
 int compat_ptrace_request(struct task_struct *child, compat_long_t request,
 			  compat_ulong_t addr, compat_ulong_t data)
@@ -1271,6 +1350,21 @@ COMPAT_SYSCALL_DEFINE4(ptrace, compat_long_t, request, compat_long_t, pid,
 		ret = -ESRCH;
 		goto out;
 	}
+
+	if (request == PTRACE_LIVEDUMP) {
+#ifdef CONFIG_LIVEDUMP
+		struct compat_livedump_param __user * datap;
+
+		datap = compat_ptr(data);
+		if (datap)
+			ret = compat_ptrace_livedump(child, datap);
+		else
+			ret = ptrace_livedump(child, NULL);
+#else
+		ret = -ENOSYS;
+#endif
+		goto out_put_task_struct;
+        }
 
 	if (request == PTRACE_ATTACH || request == PTRACE_SEIZE) {
 		ret = ptrace_attach(child, request, addr, data);

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -44,6 +44,7 @@
 
 #define CREATE_TRACE_POINTS
 #include <trace/events/signal.h>
+#include <linux/livedump.h>
 
 #include <asm/param.h>
 #include <linux/uaccess.h>
@@ -142,7 +143,8 @@ static int recalc_sigpending_tsk(struct task_struct *t)
 {
 	if ((t->jobctl & JOBCTL_PENDING_MASK) ||
 	    PENDING(&t->pending, &t->blocked) ||
-	    PENDING(&t->signal->shared_pending, &t->blocked)) {
+	    PENDING(&t->signal->shared_pending, &t->blocked) ||
+	    is_livedump_sigpending(t)) {
 		set_tsk_thread_flag(t, TIF_SIGPENDING);
 		return 1;
 	}
@@ -1006,6 +1008,9 @@ static int __send_signal(int sig, struct siginfo *info, struct task_struct *t,
 	int ret = 0, result;
 
 	assert_spin_locked(&t->sighand->siglock);
+
+	if (!livedump_check_signal_send(sig, t))
+		return 0;
 
 	result = TRACE_SIGNAL_IGNORED;
 	if (!prepare_signal(sig, t,
@@ -2323,6 +2328,14 @@ int get_signal(struct ksignal *ksig)
 
 relock:
 	spin_lock_irq(&sighand->siglock);
+
+	if (is_livedump_sigpending(current)) {
+		clear_livedump_sigpending(current);
+		spin_unlock_irq(&sighand->siglock);
+		livedump_handle_signal(&ksig->info);
+		spin_lock_irq(&sighand->siglock);
+	}
+
 	/*
 	 * Every stopped thread goes here after wakeup. Check to see if
 	 * we should notify the parent, prepare_signal(SIGCONT) encodes
@@ -2578,6 +2591,8 @@ void exit_signals(struct task_struct *tsk)
 	 * see wants_signal(), do_signal_stop().
 	 */
 	tsk->flags |= PF_EXITING;
+
+	livedump_handle_exit(tsk);
 
 	cgroup_threadgroup_change_end(tsk);
 

--- a/tools/testing/selftests/Makefile
+++ b/tools/testing/selftests/Makefile
@@ -17,6 +17,7 @@ TARGETS += ipc
 TARGETS += kcmp
 TARGETS += kvm
 TARGETS += lib
+TARGETS += livedump
 TARGETS += membarrier
 TARGETS += memfd
 TARGETS += memory-hotplug

--- a/tools/testing/selftests/livedump/Makefile
+++ b/tools/testing/selftests/livedump/Makefile
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0
+# Makefile for livedump selftests.
+CFLAGS = -Wall -O2
+
+TEST_GEN_PROGS := lacdtest
+
+include ../lib.mk
+
+override RUN_TESTS := if [ -f /proc/self/livedump ] ; \
+		      then	\
+				./lacdtest ; \
+		      else	\
+				echo "WARN: No /proc/self/livedump exists, test skipped." ; \
+		      fi
+override EMIT_TESTS := echo "$(RUN_TESTS)"

--- a/tools/testing/selftests/livedump/lacdtest.c
+++ b/tools/testing/selftests/livedump/lacdtest.c
@@ -1,0 +1,542 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <stdio.h>
+#include <malloc.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdarg.h>
+
+const char *iotmp = "/tmp/lacdtest.XXXXXX";
+
+int do_io(volatile bool *term, void *dummy)
+{
+	while (!*term) {
+		char *fname = malloc(strlen(iotmp) + 1);
+		int fd, i;
+
+		strcpy(fname, iotmp);
+		fd = mkstemp(fname);
+		if (fd == -1) {
+			fprintf(stderr, "Error creating tmp file: %s\n",
+				strerror(errno));
+			sleep(1);
+			continue;
+		}
+
+		for (i = 0; i < 1000; i++)
+			write(fd, fname, strlen(fname));
+
+		close(fd);
+
+		unlink(fname);
+		free(fname);
+	}
+
+	return 0;
+}
+
+void *spawn(void *dummy)
+{
+	return NULL;
+}
+
+int spawner(volatile bool *term, void *dummy)
+{
+	pthread_t th;
+
+	while (!*term) {
+		int rv = pthread_create(&th, NULL, spawn, NULL);
+		if (!rv)
+			pthread_join(th, NULL);
+		else
+			sleep(1);
+	}
+
+	return 0;
+}
+
+int alloc_sprintf(char **str, const char *fmt, ...)
+{
+	int len;
+	va_list ap;
+	char *s;
+
+	va_start(ap, fmt);
+	len = vsnprintf(NULL, 0, fmt, ap);
+	va_end(ap);
+
+	if (len < 0)
+		return -1;
+
+	len++;
+	s = malloc(len);
+	if (!s)
+		return -1;
+
+	va_start(ap, fmt);
+	len = vsnprintf(s, len, fmt, ap);
+	va_end(ap);
+
+	if (len < 0) {
+		free(s);
+		return -1;
+	}
+
+	*str = s;
+	return len;
+}
+
+const char *dumpstr = "core_limit=0\n";
+
+int coredump_proc(const char *name, int pid)
+{
+	char *fname;
+	int rv, fd;
+
+	if (name && pid)
+		rv = alloc_sprintf(&fname, "/proc/%s/%d/livedump", name, pid);
+	else if (name)
+		rv = alloc_sprintf(&fname, "/proc/%s/livedump", name);
+	else
+		rv = alloc_sprintf(&fname, "/proc/%d/livedump", pid);
+	if (rv == -1) {
+		fprintf(stderr, "Error allocating filename: %s\n",
+			strerror(errno));
+		return -1;
+	}
+
+	fd = open(fname, O_WRONLY);
+	if (fd == -1) {
+		fprintf(stderr, "Error opening '%s': %s\n", fname,
+			strerror(errno));
+		free(fname);
+		return -1;
+	}
+	free(fname);
+
+	rv = write(fd, dumpstr, strlen(dumpstr));
+	if (rv == -1) {
+		fprintf(stderr, "Error writing to '%s': %s\n", fname,
+			strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	close(fd);
+
+	return 0;
+}
+
+int coredump_self(void)
+{
+	return coredump_proc("self", 0);
+}
+
+int coredump_from_fork(void)
+{
+	pid_t pid = getpid();
+	pid_t rv;
+	int status;
+
+	rv = fork();
+	if (rv == -1) {
+		fprintf(stderr, "Error from fork: %s\n", strerror(errno));
+		return -1;
+	}
+	if (rv == 0) {
+		/* Child process, just do the coredump and exit. */
+		rv = coredump_proc(NULL, pid);
+		if (rv == -1)
+			exit(1);
+		exit(0);
+	} else {
+		pid = waitpid(rv, &status, 0);
+		if (pid < 0) {
+			fprintf(stderr, "Error waiting for pid: %s\n",
+				strerror(errno));
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+static void *coredump_th(void *dummy)
+{
+	int rv = coredump_proc("self", 0);
+
+	return ((void *) (long) rv);
+}
+
+int coredump_from_th(void)
+{
+	int rv;
+	pthread_t th;
+	void *data;
+
+	rv = pthread_create(&th, NULL, coredump_th, NULL);
+	if (rv) {
+		fprintf(stderr, "pthread_create on dumper failed: %s\n",
+			strerror(rv));
+		return -1;
+	}
+
+	rv = pthread_join(th, &data);
+	if (rv) {
+		fprintf(stderr,
+			"pthread_join on dumper failed: %s\n",
+			strerror(rv));
+	} else {
+		rv = (long) data;
+		if (rv)
+			return -1;
+	}
+
+	return 0;
+}
+
+struct coredump_th_data;
+
+struct per_th_data {
+	struct coredump_th_data *d;
+	pthread_t tid;
+	int result;
+};
+
+struct coredump_th_data {
+	int (*op)(volatile bool *term, void *data);
+	void *data; /* User data */
+
+	volatile bool terminate;
+	struct per_th_data *thd;
+	int (*do_coredump)(void);
+	int dump_result;
+};
+
+void *th_run_op(void *dptr)
+{
+	struct per_th_data *thd = dptr;
+	struct coredump_th_data *d = thd->d;
+
+	thd->result = d->op(&d->terminate, d->data);
+	return NULL;
+}
+
+int iterate_coredumps(int iterations, int (*do_coredump)(void))
+{
+	int rv = 0;
+	int nsuccess = 0, nerrs = 0;
+	int column = 80;
+
+	if (iterations == 1)
+		return do_coredump();
+
+	while (iterations != 0) {
+		rv = do_coredump();
+		if (rv == -1) {
+			if (errno == EINPROGRESS) {
+				nerrs++;
+				fwrite("P", 1, 1, stdout);
+			} else if (errno == EAGAIN) {
+				nerrs++;
+				fwrite("G", 1, 1, stdout);
+			} else {
+				fprintf(stderr, "Write error: %s\n",
+					strerror(errno));
+				return -1;
+			}
+		} else {
+			nsuccess++;
+			fwrite(".", 1, 1, stdout);
+		}
+		iterations--;
+		if (iterations) {
+			column--;
+			if (column == 0)
+				column = 81 - printf("\n%d %d: ",
+						     nsuccess, nerrs);
+			fflush(stdout);
+		}
+	}
+	printf("\n");
+
+	return 0;
+}
+
+int coredump_with_threads(int nthreads, int iterations,
+			  int (*op)(volatile bool *term, void *data),
+			  void *data,
+			  int (*do_coredump)(void))
+{
+	int i, rv, result;
+	struct coredump_th_data *d;
+
+	d = malloc(sizeof(*d));
+	if (!d) {
+		fprintf(stderr, "Unable to alloc coredump data");
+		return -1;
+	}
+	memset(d, 0, sizeof(*d));
+	d->thd = malloc(sizeof(*d->thd) * nthreads);
+	if (!d->thd) {
+		free(d);
+		fprintf(stderr, "Unable to allocate per-thread data\n");
+		return -1;
+	}
+	memset(d->thd, 0, sizeof(*d->thd) * nthreads);
+	d->op = op;
+	d->data = data;
+
+	for (i = 0; i < nthreads; i++) {
+		d->thd[i].d = d;
+		rv = pthread_create(&d->thd[i].tid, NULL, th_run_op,
+				    &d->thd[i]);
+		if (rv) {
+			fprintf(stderr, "pthread_create: %s\n", strerror(rv));
+			break;
+		}
+	}
+
+	if (rv) {
+		result = -1;
+	} else {
+		sleep(2);
+		iterate_coredumps(iterations, do_coredump);
+	}
+
+	d->terminate = true;
+	for (i--; i >= 0; i--) {
+		rv = pthread_join(d->thd[i].tid, NULL);
+		if (rv) {
+			result = -1;
+			fprintf(stderr, "pthread_join failed: %s\n",
+				strerror(rv));
+		}
+		if (d->thd[i].result) {
+			result = -1;
+			fprintf(stderr, "thread %d failed with: %s\n",
+				i, strerror(d->thd[i].result));
+		}
+	}
+
+	free(d->thd);
+	free(d);
+
+	return result;
+}
+
+int just_coredump(int nthreads, int iterations,
+		  int (*op)(volatile bool *term, void *data), void *data,
+		  int (*do_coredump)(void))
+{
+	return iterate_coredumps(iterations, do_coredump);
+}
+
+struct coredump_tests {
+	const char *name;
+	const char *descr;
+	int (*func)(int nthreads, int iterations,
+		    int (*op)(volatile bool *term, void *data), void *data,
+		    int (*do_coredump)(void));
+	int (*op)(volatile bool *term, void *data);
+	int (*dump)(void);
+} tests[] = {
+	{
+		"self",
+		"A single-thread process takes a coredump of itself.",
+		just_coredump, NULL, coredump_self
+	},
+	{
+		"selfth",
+		"A process takes a coredump of itself from a subthread.",
+		just_coredump, NULL, coredump_from_th
+	},
+	{
+		"proc",
+		"Another process takes a coredump of a single-thread\n"
+		"  process.",
+		just_coredump, NULL, coredump_from_fork
+	},
+	{
+		"spawner-self",
+		"A thread takes a coredump of itself while multiple\n"
+		"  threads spawn other threads.",
+		coredump_with_threads, spawner, coredump_from_fork
+	},
+	{
+		"spawner-selfth",
+		"A sub-thread takes a coredump of itself while multiple\n"
+		"  threads spawn other threads.",
+		coredump_with_threads, spawner, coredump_from_fork
+	},
+	{
+		"spawner-proc",
+		"Another process takes a coredump of a process while\n"
+		"  multiple threads spawn other threads.",
+		coredump_with_threads, spawner, coredump_from_fork
+	},
+	{
+		"io-self",
+		"A thread takes a coredump of itself while multiple\n"
+		"  threads do I/O.",
+		coredump_with_threads, do_io, coredump_from_fork
+	},
+	{
+		"io-selfth",
+		"A sub-thread takes a coredump of itself while\n"
+		"  multiple threads do I/O.",
+		coredump_with_threads, do_io, coredump_from_fork
+	},
+	{
+		"io-proc",
+		"Another process takes a coredump of a process while\n"
+		"  multiple threads do I/O.",
+		coredump_with_threads, do_io, coredump_from_fork
+	},
+	{ NULL }
+};
+
+bool streq(const char *a, const char *b)
+{
+	return strcmp(a, b) == 0;
+}
+
+bool strstart(const char *a, const char *b, int *pos)
+{
+	bool rv;
+	int len = strlen(b);
+	
+	rv = strncmp(a, b, len) == 0;
+	if (rv)
+		*pos = len;
+
+	return rv;
+}
+
+int parse_int(int *val, int argc, char *argv[], int *i, int pos)
+{
+	char *nstr;
+	char *end;
+
+	if (pos >= 0 && argv[*i][pos] == '=') {
+		/* Number is after the = in the arg. */
+		nstr = &(argv[*i][pos + 1]);
+	} else {
+		if (*i + 1 >= argc) {
+			fprintf(stderr, "No argument for parameter %s\n",
+				argv[*i]);
+			return -1;
+		}
+		nstr = argv[*i + 1];
+		(*i)++;
+	}
+
+	if (strlen(nstr) == 0) {
+		fprintf(stderr, "Empty argument for parameter %s\n", argv[*i]);
+		return -1;
+	}
+
+	*val = strtol(nstr, &end, 0);
+	if (*end != '\0') {
+		fprintf(stderr, "Invalid argument for parameter %s\n",
+			argv[*i]);
+		return -1;
+	}
+
+	return 0;
+}
+
+int run_test(struct coredump_tests *t, int i, int nthreads, int iterations)
+{
+	printf("Running test %s: %s\n", t[i].name, t[i].descr);
+	return t[i].func(nthreads, iterations, t[i].op, NULL, t[i].dump);
+}
+
+const char *helpstr = "\
+Test the live application coredump feature\n\
+   %s [-n <n>] [--num_threads=<n>] [-i] [--iterations=<n>] [-t]\n\
+      [--take-coredump] [-h] ] [--help] [<testcase>]\n\
+Parameters:\n\
+  -n | --num_threads   - The number of threads to spawn for threaded tests\n\
+  -i | --iterations    - The number of coredumps to take\n\
+  -t | --take-coredump - Actually save a coredump.\n\
+  -h | --help          - This help\n\
+Normally the core limit is set to zero, use -t if you want to actually save\n\
+a core.  If no testcase is specified, they are all run\n\
+Testcases are:\n";
+
+void help(const char *progname)
+{
+	int i;
+
+	printf(helpstr, progname);
+	for (i = 0; tests[i].name; i++)
+		printf("  %s: %s\n", tests[i].name, tests[i].descr);
+}
+
+int main(int argc, char *argv[])
+{
+	int rv;
+	int i = 1, parm;
+	int nthreads = 20;
+	int iterations = 1;
+	
+	for (; i < argc && argv[i][0] == '-'; i++) {
+		int pos = -1;
+
+		rv = 0;
+		if (streq(argv[i], "-n") ||
+		    strstart(argv[i], "--num-threads", &pos)) {
+			rv = parse_int(&nthreads, argc, argv, &i, pos);
+		} else if (streq(argv[i], "-i") ||
+			   strstart(argv[i], "--iterations", &pos)) {
+			rv = parse_int(&iterations, argc, argv, &i, pos);
+		} else if (streq(argv[i], "-t") ||
+			   streq(argv[i], "--take-coredump")) {
+			dumpstr = "core_limit=unlimited\n";
+		} else if (streq(argv[i], "-h") ||
+			   streq(argv[i], "--help")) {
+			help(argv[0]);
+			return 0;
+		} else {
+			fprintf(stderr, "Unknown parameter: %s\n", argv[i]);
+			return -1;
+		}
+		if (rv)
+			return -1;
+	}
+
+	parm = i;
+	rv = 0;
+	if (parm == argc) {
+		for (i = 0; tests[i].name; i++) {
+			rv = run_test(tests, i, nthreads, iterations);
+			if (rv)
+				break;
+		}
+	} else {
+		for (; parm < argc; parm++) {
+			for (i = 0; tests[i].name; i++) {
+				if (streq(tests[i].name, argv[parm])) {
+					rv = run_test(tests, i, nthreads,
+						      iterations);
+					break;
+				}
+			}
+			if (!tests[i].name) {
+				fprintf(stderr, "Unknown testcase: %s\n",
+					argv[parm]);
+				return -1;
+			}
+		}
+	}
+
+	return rv;
+}


### PR DESCRIPTION
As task-stack related APIs moved from <linux/sched.h> to
<linux/sched/task_stack.h> in commit f3ac60671954,
modify include for the same.

This fixes below build error:

kernel/livedump.c: In function ‘livedump_clone’:
./arch/arm/include/asm/processor.h:86:40: error: implicit declaration of function ‘task_stack_page’; did you mean ‘task_stack_vm_area’? [-Werror=implicit-function-declaration]
  ((struct pt_regs *)(THREAD_START_SP + task_stack_page(p)) - 1)
                                        ^
./arch/arm/include/asm/processor.h:89:23: note: in expansion of macro ‘task_pt_regs’
 #define KSTK_ESP(tsk) task_pt_regs(tsk)->ARM_sp
                       ^~~~~~~~~~~~
kernel/livedump.c:165:9: note: in expansion of macro ‘KSTK_ESP’
         KSTK_ESP(current), 0, NULL, pid, 0, 0,
         ^~~~~~~~
cc1: some warnings being treated as errors
make[1]: *** [kernel/livedump.o] Error 1

Signed-off-by: Rupesh Kumar <rupeshk@mvista.com>